### PR TITLE
💄 Design:  댓글 입력에 따라 동적으로 크기 조절 되도록 디자인 변경

### DIFF
--- a/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
+++ b/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CommentSheetView: View {
     @State private var commentText: String = ""
+    @State var width = UIScreen.main.bounds.width
     
     @StateObject private var commentVM = CommentViewModel()
     
@@ -47,36 +48,36 @@ struct CommentSheetView: View {
                 ZStack {
                     HStack {
                         CircularImageView(size: .medium)
+                        
                         ZStack {
-                            TextEditor(text: $commentText)
-                                .font(.system(size: 14))
-                                .padding()
-                                .background(
-                                    RoundedRectangle(cornerRadius: 26)
-                                        .strokeBorder(Color.gray, lineWidth: 0.5)
-                                )
-                                .frame(height: 50)
-                            
-                            
-                            HStack {
-                                Spacer()
+                            VStack {
+                                HStack {
+                                    TextField("여기에 입력하세요",
+                                              text: $commentText,
+                                              axis: .vertical) // 세로 축으로 동적 높이 조절 활성화
                                 
-                                Button {
-                                    // 댓글 입력 로직
-                                } label: {
-                                    ZStack {
-                                        RoundedRectangle(cornerRadius: 26)
-                                            .frame(width: 50, height: 30)
-                                            .foregroundStyle(.blue)
-                                        Image(systemName: "arrow.up")
-                                            .resizable()
-                                            .frame(width: 15, height: 15)
-                                            .foregroundStyle(.white)
-                                            .bold()
+                                    Button {
+                                        // 댓글 입력 로직
+                                    } label: {
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 26)
+                                                .frame(width: 50, height: 30)
+                                                .foregroundStyle(.blue)
+                                            Image(systemName: "arrow.up")
+                                                .resizable()
+                                                .frame(width: 15, height: 15)
+                                                .foregroundStyle(.white)
+                                                .bold()
+                                        }
                                     }
                                 }
+                                .padding(.vertical, -5)
                             }
-                            .padding(.horizontal, 10)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 36) // HStack의 크기에 맞게 동적으로 크기가 변하는 RoundedRectangle
+                                    .stroke(Color.gray, lineWidth: 1)
+                            )
                         }
                     }
                     .padding(.horizontal)
@@ -86,7 +87,7 @@ struct CommentSheetView: View {
         }
     }
 }
-    
+
 struct CommentView: View {
     var body: some View {
         CommentSheetView()


### PR DESCRIPTION
### 댓글 입력창 디자인 수정
- TextField의 axis 파라미터를 통해 Dynamic Height로 동작하는 입력 인터페이스 적용
```swift
HStack {
    TextField("여기에 입력하세요",
              text: $commentText,
              axis: .vertical) // 세로 축으로 동적 높이 조절 활성화
}
```


> [!NOTE]
> iOS 16 이상에 적용가능한 파라미터이기 때문에, Deployment 타겟 변경 시, 수정 필요합니다.

### 적용화면

![스크린샷 2024-01-30 오후 12 21 29](https://github.com/4T2F/PADO/assets/103357078/3054d324-92e4-47ef-92f3-f17c5a5b2430)