### PR TITLE
🌊 Feat: 파이어 베이스에서 댓글 쓰기 기능 구현

### DIFF
--- a/PADO/PADO/iOS/ContentView.swift
+++ b/PADO/PADO/iOS/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     
     @StateObject var surfingVM = SurfingViewModel()
     @StateObject var feedVM = FeedViewModel()
+    @StateObject var commentVM = CommentViewModel()
     
     @State private var selectedTab = 0
     
@@ -31,7 +32,7 @@ struct ContentView: View {
         NavigationStack {
             GeometryReader { geometry in
                 TabView(selection: $selectedTab) {
-                    FeedView(feedVM: feedVM)
+                    FeedView(feedVM: feedVM, commentVM: commentVM)
                         .tabItem {
                             Image(selectedTab == 0 ? "home_light" : "home_gray")
                                 

--- a/PADO/PADO/iOS/Helpers/Services/UpdateUserData.swift
+++ b/PADO/PADO/iOS/Helpers/Services/UpdateUserData.swift
@@ -26,6 +26,4 @@ class UpdateUserData {
             print("Error updating document: \(error)")
         }
     }
-    
-    
 }

--- a/PADO/PADO/iOS/MainView/Comment/Cell/CommentCell.swift
+++ b/PADO/PADO/iOS/MainView/Comment/Cell/CommentCell.swift
@@ -16,7 +16,7 @@ struct CommentCell: View {
                 .fill(Color.gray)
                 .frame(width: 35, height: 35)
                 .overlay(
-                    Text(comment.nameID.prefix(1))
+                    Text(comment.userID.prefix(1))
                         .fontWeight(.semibold)
                         .foregroundColor(.white)
                 )
@@ -24,11 +24,11 @@ struct CommentCell: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
-                    Text(comment.nameID)
+                    Text(comment.userID)
                         .fontWeight(.semibold)
                         .font(.system(size: 14))
                         .padding(.trailing, 4)
-                    Text(comment.time)
+                    Text(comment.userID)
                         .font(.caption)
                         .foregroundColor(.secondary)
                     
@@ -42,14 +42,10 @@ struct CommentCell: View {
                     }
                 }
                 
-                Text(comment.comment)
+                Text(comment.content)
                     .font(.system(size: 14))
                     .foregroundStyle(.white)
             }
         }
     }
-}
-
-#Preview {
-    CommentCell(comment: Comment(nameID: "dearkang", comment: "하하하 너무재밌네요", time: "1분 전"))
 }

--- a/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
+++ b/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
@@ -62,7 +62,11 @@ struct CommentSheetView: View {
                                 Spacer()
                                 
                                 Button {
-                                    // 댓글 입력 로직
+                                    Task {
+                                        await commentVM.writeComment(inputcomment: commentText)
+                                        commentText = ""
+                                        await commentVM.getCommentsDocument()
+                                    }
                                 } label: {
                                     ZStack {
                                         RoundedRectangle(cornerRadius: 26)

--- a/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
+++ b/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
@@ -55,23 +55,24 @@ struct CommentSheetView: View {
                                     TextField("여기에 입력하세요",
                                               text: $commentText,
                                               axis: .vertical) // 세로 축으로 동적 높이 조절 활성화
-                                
-                                Button {
-                                    Task {
-                                        await commentVM.writeComment(inputcomment: commentText)
-                                        commentText = ""
-                                        await commentVM.getCommentsDocument()
-                                    }
-                                } label: {
-                                    ZStack {
-                                        RoundedRectangle(cornerRadius: 26)
-                                            .frame(width: 50, height: 30)
-                                            .foregroundStyle(.blue)
-                                        Image(systemName: "arrow.up")
-                                            .resizable()
-                                            .frame(width: 15, height: 15)
-                                            .foregroundStyle(.white)
-                                            .bold()
+                                    
+                                    Button {
+                                        Task {
+                                            await commentVM.writeComment(inputcomment: commentText)
+                                            commentText = ""
+                                            await commentVM.getCommentsDocument()
+                                        }
+                                    } label: {
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 26)
+                                                .frame(width: 50, height: 30)
+                                                .foregroundStyle(.blue)
+                                            Image(systemName: "arrow.up")
+                                                .resizable()
+                                                .frame(width: 15, height: 15)
+                                                .foregroundStyle(.white)
+                                                .bold()
+                                        }
                                     }
                                 }
                                 .padding(.vertical, -5)

--- a/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
+++ b/PADO/PADO/iOS/MainView/Comment/View/CommentView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct CommentSheetView: View {
     @State private var commentText: String = ""
-    
-    @StateObject private var commentVM = CommentViewModel()
+    @ObservedObject var commentVM: CommentViewModel
+    @ObservedObject var feedVM: FeedViewModel
     
     var body: some View {
         ZStack {
@@ -86,14 +86,12 @@ struct CommentSheetView: View {
         }
     }
 }
-    
+
 struct CommentView: View {
+    @ObservedObject var commentVM: CommentViewModel
+    @ObservedObject var feedVM: FeedViewModel
+    
     var body: some View {
-        CommentSheetView()
+        CommentSheetView(commentVM: commentVM, feedVM: feedVM)
     }
 }
-
-#Preview {
-    CommentSheetView()
-}
-

--- a/PADO/PADO/iOS/MainView/Comment/ViewModel/CommentViewModel.swift
+++ b/PADO/PADO/iOS/MainView/Comment/ViewModel/CommentViewModel.swift
@@ -6,19 +6,26 @@
 //
 
 import SwiftUI
+import Firebase
+import FirebaseFirestore
 
-
-
+@MainActor
 final class CommentViewModel: ObservableObject {
-    @Published var comments: [Comment] = [
-        Comment(nameID: "2222", comment: "하하하, 너무 재밌네요...", time: "1분 전"),
-        Comment(nameID: "MinJi", comment: "그쵸! 제가 좀 재밌어요~", time: "3분 전"),
-        Comment(nameID: "BestCha", comment: "잘 모르겠습니다..", time: "4분 전"),
-        Comment(nameID: "A-heung", comment: "이런흥아흥아흥!", time: "5분 전"),
-        Comment(nameID: "pinkso", comment: "솔직히 저 예쁘지 않아요?", time: "8분 전"),
-        Comment(nameID: "pado", comment: "넌 손해 좀 보자", time: "13분 전"),
-        Comment(nameID: "ciu", comment: "솔직히 저 예쁘지 않아요?", time: "15분 전"),
-        Comment(nameID: "myunghyun", comment: "이런흥아흥아흥!", time: "17분 전"),
-        Comment(nameID: "minchae", comment: "솔직히 저 예쁘지 않아요?", time: "24분 전")
-    ]
+    
+    @Published var comments: [Comment] = []
+    @Published var documentID: String = ""
+    
+    let db = Firestore.firestore()
+    
+    // 포스트 - 포스팅제목 - 서브컬렉션 포스트에 접근해서 문서 댓글정보를 가져와 comments 배열에 할당
+    func getCommentsDocument() async {
+        do {
+            let querySnapshot = try await db.collection("post").document(documentID).collection("comment").getDocuments()
+            self.comments = querySnapshot.documents.compactMap { document in
+                try? document.data(as: Comment.self)
+            }
+        } catch {
+            print("Error fetching comments: \(error)")
+        }
+    }
 }

--- a/PADO/PADO/iOS/MainView/Comment/ViewModel/CommentViewModel.swift
+++ b/PADO/PADO/iOS/MainView/Comment/ViewModel/CommentViewModel.swift
@@ -14,10 +14,11 @@ final class CommentViewModel: ObservableObject {
     
     @Published var comments: [Comment] = []
     @Published var documentID: String = ""
+    @Published var inputcomment: String = ""
     
     let db = Firestore.firestore()
     
-    // 포스트 - 포스팅제목 - 서브컬렉션 포스트에 접근해서 문서 댓글정보를 가져와 comments 배열에 할당
+    // MARK: 포스트 - 포스팅제목 - 서브컬렉션 포스트에 접근해서 문서 댓글정보를 가져와 comments 배열에 할당
     func getCommentsDocument() async {
         do {
             let querySnapshot = try await db.collection("post").document(documentID).collection("comment").getDocuments()
@@ -26,6 +27,24 @@ final class CommentViewModel: ObservableObject {
             }
         } catch {
             print("Error fetching comments: \(error)")
+        }
+    }
+    // MARK: - 댓글 작성
+    func writeComment(inputcomment: String) async {
+        // 게시 요청 관련 로직 추가
+        let initialPostData : [String: Any] = [
+            "userID": userNameID,
+            "content": inputcomment,
+            "time": Timestamp()
+       ]
+        await createCommentData(documentName: documentID, data: initialPostData)
+    }
+    
+    func createCommentData(documentName: String, data: [String: Any]) async {
+        do {
+            try await db.collection("post").document(documentName).collection("comment").document(userNameID).setData(data)
+        } catch {
+            print("Error saving post data: \(error.localizedDescription)")
         }
     }
 }

--- a/PADO/PADO/iOS/MainView/Comment/ViewModel/CommentViewModel.swift
+++ b/PADO/PADO/iOS/MainView/Comment/ViewModel/CommentViewModel.swift
@@ -31,7 +31,6 @@ final class CommentViewModel: ObservableObject {
     }
     // MARK: - 댓글 작성
     func writeComment(inputcomment: String) async {
-        // 게시 요청 관련 로직 추가
         let initialPostData : [String: Any] = [
             "userID": userNameID,
             "content": inputcomment,
@@ -41,8 +40,14 @@ final class CommentViewModel: ObservableObject {
     }
     
     func createCommentData(documentName: String, data: [String: Any]) async {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd-HH:mm:ss.sssZ"
+        
+        let formattedDate = dateFormatter.string(from: Date())
+        let formattedCommentTitle = userNameID+formattedDate
+        
         do {
-            try await db.collection("post").document(documentName).collection("comment").document(userNameID).setData(data)
+            try await db.collection("post").document(documentName).collection("comment").document(formattedCommentTitle).setData(data)
         } catch {
             print("Error saving post data: \(error.localizedDescription)")
         }

--- a/PADO/PADO/iOS/MainView/Feed/Cell/HeartCommentCell.swift
+++ b/PADO/PADO/iOS/MainView/Feed/Cell/HeartCommentCell.swift
@@ -14,7 +14,8 @@ struct HeartCommentCell: View {
     @Binding var isShowingReportView: Bool
     @Binding var isShowingCommentView: Bool
     
-    @ObservedObject var vm: FeedViewModel
+    @ObservedObject var feedVM: FeedViewModel
+    @ObservedObject var commentVM: CommentViewModel
     
     var body: some View {
         VStack(spacing: 16) {
@@ -31,7 +32,7 @@ struct HeartCommentCell: View {
                     }
                 }
                 // 하트 눌렀을 때 +1 카운팅 되게 하는 로직 추가
-                Text("\(vm.selectedFeedHearts)")
+                Text("\(feedVM.selectedFeedHearts)")
                     .font(.system(size: 12))
                     .fontWeight(.semibold)
                     .shadow(radius: 1, y: 1)
@@ -44,12 +45,12 @@ struct HeartCommentCell: View {
                     Image("chat")
                 }
                 .sheet(isPresented: $isShowingCommentView) {
-                    CommentView()
+                    CommentView(commentVM: commentVM, feedVM: feedVM)
                         .presentationDetents([.fraction(0.99), .fraction(0.8)])
                         .presentationDragIndicator(.visible)
                 }
                 // 댓글이 달릴 때 마다 +1 카운팅 되게 하는 로직 추가
-                Text("13")
+                Text(String(commentVM.comments.count))
                     .font(.system(size: 12))
                     .fontWeight(.semibold)
                     .shadow(radius: 1, y: 1)

--- a/PADO/PADO/iOS/MainView/Feed/Cell/StoryCell.swift
+++ b/PADO/PADO/iOS/MainView/Feed/Cell/StoryCell.swift
@@ -16,7 +16,8 @@ struct StoryCell: View {
     var storyIndex: Int
 
     @State var imageProfileUrl: String = ""
-    @ObservedObject var vm: FeedViewModel
+    @ObservedObject var feedVM: FeedViewModel
+    @ObservedObject var commentVM: CommentViewModel
 
     var onTap: () -> Void  // 탭 동작을 위한 클로저
     
@@ -32,7 +33,7 @@ struct StoryCell: View {
         }
         .onAppear {
             Task {
-                imageProfileUrl = await vm.setupProfileImageURL(id: story.name)
+                imageProfileUrl = await feedVM.setupProfileImageURL(id: story.name)
                 
                 if storyIndex == 0 {
                     setFeedData()
@@ -46,10 +47,14 @@ struct StoryCell: View {
     }
     
     func setFeedData() {
-        vm.feedProfileID = story.name
-        vm.feedProfileImageUrl = imageProfileUrl
-        vm.selectedFeedTitle = story.title
-        vm.selectedFeedTime = TimestampDateFormatter.formatDate(story.postTime)
-        vm.selectedFeedHearts = story.hearts
+        feedVM.feedProfileID = story.name
+        feedVM.feedProfileImageUrl = imageProfileUrl
+        feedVM.selectedFeedTitle = story.title
+        feedVM.selectedFeedTime = TimestampDateFormatter.formatDate(story.postTime)
+        feedVM.selectedFeedHearts = story.hearts
+        commentVM.documentID = story.postID
+        Task {
+            await commentVM.getCommentsDocument()
+        }
     }
 }

--- a/PADO/PADO/iOS/MainView/Feed/Model/StoryModel.swift
+++ b/PADO/PADO/iOS/MainView/Feed/Model/StoryModel.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 struct Story: Identifiable, Hashable {
     let id = UUID()
+    
+    let postID: String
     let name: String
     let image: String
     let title: String

--- a/PADO/PADO/iOS/MainView/Feed/View/FeedView.swift
+++ b/PADO/PADO/iOS/MainView/Feed/View/FeedView.swift
@@ -15,7 +15,7 @@ struct FeedView: View {
     @EnvironmentObject var authenticationViewModel: AuthenticationViewModel
     
     @StateObject var feedVM: FeedViewModel
-    @StateObject private var commentVM = CommentViewModel()
+    @ObservedObject var commentVM: CommentViewModel
     @StateObject private var mainCommentVM = MainCommentViewModel()
     @StateObject private var mainFaceMojiVM = MainFaceMojiViewModel()
     
@@ -81,7 +81,7 @@ struct FeedView: View {
                     Spacer()
                     
                     // MARK: - HeartComment
-                    HeartCommentCell(isShowingReportView: $feedVM.isShowingReportView, isShowingCommentView: $feedVM.isShowingCommentView, vm: feedVM)
+                    HeartCommentCell(isShowingReportView: $feedVM.isShowingReportView, isShowingCommentView: $feedVM.isShowingCommentView, feedVM: feedVM, commentVM: commentVM)
                         .padding(.leading, UIScreen.main.bounds.width)
                         .padding(.trailing, 60)
                         .padding(.bottom, 10)
@@ -91,7 +91,7 @@ struct FeedView: View {
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 16) {
                                 ForEach(Array(feedVM.stories.enumerated()), id: \.element) { index, story in
-                                    StoryCell(story: story, storyIndex: index, vm: feedVM) {
+                                    StoryCell(story: story, storyIndex: index, feedVM: feedVM, commentVM: commentVM) {
                                         self.feedVM.selectStory(story)
                                     }
                                 }

--- a/PADO/PADO/iOS/MainView/Feed/ViewModel/FeedViewModel.swift
+++ b/PADO/PADO/iOS/MainView/Feed/ViewModel/FeedViewModel.swift
@@ -27,6 +27,8 @@ class FeedViewModel: ObservableObject {
     @Published var selectedFeedTime: String = ""
     @Published var selectedFeedHearts: Int = 0
     
+    @Published var documentID: String = ""
+    
     private var db = Firestore.firestore()
     private var listener: ListenerRegistration?
     
@@ -79,7 +81,7 @@ class FeedViewModel: ObservableObject {
     // Firestore의 데이터를 기반으로 스토리 데이터 업데이트
     private func updateStories() {
         self.stories = self.post.map { post in
-            Story(name: post.ownerUid, image: post.imageUrl, title: post.title, postTime: post.created_Time, hearts: post.hearts)
+            Story(postID: post.id ?? "error", name: post.ownerUid, image: post.imageUrl, title: post.title, postTime: post.created_Time, hearts: post.hearts)
         }
     }
     

--- a/PADO/PADO/iOS/Model/Comment.swift
+++ b/PADO/PADO/iOS/Model/Comment.swift
@@ -6,10 +6,13 @@
 //
 
 import Foundation
+import Firebase
+import FirebaseFirestore
 
 struct Comment: Identifiable, Codable {
-    var id = UUID()
-    let nameID: String
-    let comment: String
-    let time: String
+    @DocumentID var id: String?
+
+    let userID: String
+    let content: String
+    let time: Timestamp?
 }

--- a/PADO/PADO/iOS/Model/Comment.swift
+++ b/PADO/PADO/iOS/Model/Comment.swift
@@ -14,5 +14,5 @@ struct Comment: Identifiable, Codable {
 
     let userID: String
     let content: String
-    let time: Timestamp?
+    let time: Timestamp
 }

--- a/PADO/PADO/iOS/Model/Post.swift
+++ b/PADO/PADO/iOS/Model/Post.swift
@@ -9,6 +9,8 @@ import Firebase
 import FirebaseFirestoreSwift
 import Foundation
 
+var formattedPostingTitle = ""
+
 struct Post: Identifiable, Codable {
     @DocumentID var id: String?
     var ownerUid: String

--- a/PADO/PADO/iOS/Surfing/View/PostView.swift
+++ b/PADO/PADO/iOS/Surfing/View/PostView.swift
@@ -96,9 +96,14 @@ struct PostView: View {
                 // 게시요청 로직
                 Task {
                     do {
-                        // 이미지 업로드 시도
+                        // 이미지 업로드 시 이전 입력 데이터 초기화
                         let uploadedImageUrl = try await updateImageUrl.updateImageUserData(uiImage: viewModel.postingUIImage, storageTypeInput: .post)
                         await viewModel.postRequest(imageURL: uploadedImageUrl)
+                        viewModel.postingTitle = ""
+                        viewModel.postingImage = Image(systemName: "photo")
+                        viewModel.postingUIImage = UIImage()
+                        viewModel.cameraImage = Image(systemName: "photo")
+                        viewModel.selectedUIImage = Image(systemName: "photo")
                         dismiss()
                     } catch {
                         print("파베 전송 오류 발생: (error.localizedDescription)")

--- a/PADO/PADO/iOS/Surfing/View/SurfingView.swift
+++ b/PADO/PADO/iOS/Surfing/View/SurfingView.swift
@@ -67,7 +67,7 @@ struct SurfingView: View {
                     } else if viewModel.selectedUIImage != Image(systemName: "photo") {
                         Button {
                             viewModel.postingImage = viewModel.selectedUIImage
-                            viewModel.postingUIImage = viewModel.selectedImage!
+                            viewModel.postingUIImage = viewModel.selectedImage ?? UIImage()
                             viewModel.showPostView.toggle()
                         } label: {
                             Text("다음")

--- a/PADO/PADO/iOS/Surfing/ViewModel/SurfingViewModel.swift
+++ b/PADO/PADO/iOS/Surfing/ViewModel/SurfingViewModel.swift
@@ -79,30 +79,17 @@ class SurfingViewModel: ObservableObject, Searchable  {
         }
     }
     
-//    @DocumentID var id: String?
-//    var ownerUid: String
-//    var sufferUid: String?
-//    var imageUrl: String
-//    var title: String
-//    var hearts: Int
-//    var comments: [Comment]?
-//    var created_Time: Timestamp
-//    var modified_Time: Timestamp?
-    
-    
     // MARK: - 게시글 요청
     func postRequest(imageURL: String) async {
         // 게시 요청 관련 로직 추가
-        guard let uid = Auth.auth().currentUser?.uid else { return }
-        
         let initialPostData : [String: Any] = [
-            "ownerUid": uid,
+            "ownerUid": userNameID,
             "imageUrl": imageURL,
             "title": postingTitle,
             "hearts": 0,
             "created_Time": Timestamp()
        ]
-        await createPostData(titleName: uid, data: initialPostData)
+        await createPostData(titleName: formattedPostingTitle, data: initialPostData)
     }
     
     func createPostData(titleName: String, data: [String: Any]) async {

--- a/PADO/PADO/iOS/Today/Cell/TodayHeartCommentCell.swift
+++ b/PADO/PADO/iOS/Today/Cell/TodayHeartCommentCell.swift
@@ -14,6 +14,9 @@ struct TodayHeartCommentCell: View {
     @Binding var isShowingReportView: Bool
     @Binding var isShowingCommentView: Bool
     
+    @StateObject var commentVM = CommentViewModel()
+    @ObservedObject var feedVM: FeedViewModel
+    
     var body: some View {
         VStack(spacing: 16) {
             VStack {
@@ -44,11 +47,11 @@ struct TodayHeartCommentCell: View {
                     Image("chat")
                 }
                 .sheet(isPresented: $isShowingCommentView) {
-                    CommentView()
+                    CommentView(commentVM: commentVM, feedVM: feedVM)
                         .presentationDetents([.fraction(0.99), .fraction(0.8)])
                         .presentationDragIndicator(.visible)
                 }
-                // 댓글이 추가 될 때 +1 카운팅 되게 하는 로직 추가
+                // 댓글이 추가 될 때 +1 카운팅 되게 하는 로직
                 Text("13")
                     .font(.system(size: 12))
                     .fontWeight(.semibold)
@@ -77,8 +80,4 @@ struct TodayHeartCommentCell: View {
             .padding(.top, -15)
         }
     }
-}
-
-#Preview {
-    TodayHeartCommentCell(isShowingReportView: .constant(false), isShowingCommentView: .constant(false))
 }


### PR DESCRIPTION
#108
[🌊 Feat: 포스팅, 스토리지 관련 데이터 구조 변경](https://github.com/4T2F/PADO/commit/cc0150e6a826314230b7f400b9a2c5595f5d2231) 
  - 스토리지 프로필 이미지 저장 이름 변경 userid로 완료
  - 스토리지 포스트 이미지 저장userid+timestamp 로 변경
  - 스토어 포스트에는 userid+timestamp / 유저에는 userid 완료
  - 스토어 유저 - 유저아이디 - 마이포스트(서브 컬렉션에 할당 포스트 제목) 할당 완료
  - 포스트 요청시 타이틀, 선택 이미지 초기화 되도록 변경완료

[🌊 Feat: 파이어 베이스에서 댓글 읽어오기 기능 구현](https://github.com/4T2F/PADO/commit/aff19c981fc93ada8a0bd4abed7a739bd109dfd7) 
  - FireStore 구조 변경
    - users - nameID - myposting - postname(nameID+timestamp) 변경
    - post - postname(nameID+timestamp) 변경
    - post - postname(nameID+timestamp) - comment - 댓글 데이터 구현
    - 스토리지 기존 uid 값 -> nameID로 변경
    - 댓글 읽어오기 기능 구현

[🌊 Feat: 파이어 베이스에서 댓글 쓰기 기능 구현](https://github.com/4T2F/PADO/commit/f08389243ee6a2a63a42f6edffa2b45919b119d5) 
  - 파이어 베이스에서 댓글 쓰기 기능 구현

[🌊 Feat: 파이어 베이스에서 댓글 규칙 변경](https://github.com/4T2F/PADO/commit/81acdeb183d33f9b120e2b0c3cf334a58f681814) 
  - 기존 UserID로 올라가던 문서 값에서 UserID + TimeStamp로 변경