### PR TITLE
🌊 Feat : 프로필에서 게시글들 최신순으로 불러오게 구현

### DIFF
--- a/PADO/PADO/iOS/Helpers/Services/UpdateImageUrl.swift
+++ b/PADO/PADO/iOS/Helpers/Services/UpdateImageUrl.swift
@@ -148,12 +148,14 @@ class UpdateImageUrl {
             case .post:
                 try await Firestore.firestore().collection("users").document(userNameID).collection("sendpost").document(formattedPostingTitle).setData([
                     "surfingID": surfingID,
-                    "userID": userNameID
+                    "userID": userNameID,
+                    "created_Time": Timestamp()
                 ])
                 
                 try await Firestore.firestore().collection("users").document(surfingID).collection("mypost").document(formattedPostingTitle).setData([
                     "surferID": userNameID,
-                    "userID": surfingID
+                    "userID": surfingID,
+                    "created_Time": Timestamp()
                 ])
                 
                 return imageUrl

--- a/PADO/PADO/iOS/MainView/Feed/View/FeedView.swift
+++ b/PADO/PADO/iOS/MainView/Feed/View/FeedView.swift
@@ -126,8 +126,11 @@ struct FeedView: View {
                                 }
                                 Button(action: {
                                     if !feedVM.postFetchLoading {
-                                        feedVM.findFollowingUsers()
-                                        followVM.initializeFollowFetch()
+                                        Task {
+                                            feedVM.findFollowingUsers()
+                                            followVM.initializeFollowFetch()
+                                            await profileVM.fetchPadoPosts(id: userNameID)
+                                        }
                                     }
                                 }) {
                                     Image("refresh")

--- a/PADO/PADO/iOS/MainView/Feed/ViewModel/FeedViewModel.swift
+++ b/PADO/PADO/iOS/MainView/Feed/ViewModel/FeedViewModel.swift
@@ -247,7 +247,8 @@ class FeedViewModel: ObservableObject {
 extension FeedViewModel {
     func addHeart() async {
         do {
-            try await db.collection("users").document(userNameID).collection("highlight").document(documentID).setData(["documentID": documentID])
+            try await db.collection("users").document(userNameID).collection("highlight").document(documentID).setData(["documentID": documentID,
+                                                                                                                        "sendHeartTime": Timestamp()])
             
             try await db.collection("post").document(documentID).collection("heart").document(userNameID).setData(["nameID": userNameID])
             // 그 다음, 'post' 문서의 'heartsCount'를 업데이트하는 트랜잭션을 시작합니다.

--- a/PADO/PADO/iOS/Profile/ViewModel/ProfileViewModel.swift
+++ b/PADO/PADO/iOS/Profile/ViewModel/ProfileViewModel.swift
@@ -43,7 +43,7 @@ class ProfileViewModel: ObservableObject {
     func fetchPadoPosts(id: String) async {
         padoPosts.removeAll()
         do {
-            let padoQuerySnapshot = try await db.collection("users").document(id).collection("mypost").getDocuments()
+            let padoQuerySnapshot = try await db.collection("users").document(id).collection("mypost").order(by: "created_Time", descending: true).getDocuments()
             for document in padoQuerySnapshot.documents {
                 await fetchPostData(documentID: document.documentID, inputType: InputPostType.pado)
             }
@@ -56,7 +56,7 @@ class ProfileViewModel: ObservableObject {
     func fetchSendPadoPosts(id: String) async {
         sendPadoPosts.removeAll()
         do {
-            let padoQuerySnapshot = try await db.collection("users").document(id).collection("sendpost").getDocuments()
+            let padoQuerySnapshot = try await db.collection("users").document(id).collection("sendpost").order(by: "created_Time", descending: true).getDocuments()
             for document in padoQuerySnapshot.documents {
                 await fetchPostData(documentID: document.documentID, inputType: InputPostType.sendPado)
             }
@@ -69,7 +69,7 @@ class ProfileViewModel: ObservableObject {
     func fetchHighlihts(id: String) async {
         highlights.removeAll()
         do {
-            let padoQuerySnapshot = try await db.collection("users").document(id).collection("highlight").getDocuments()
+            let padoQuerySnapshot = try await db.collection("users").document(id).collection("highlight").order(by: "sendHeartTime", descending: true).getDocuments()
             for document in padoQuerySnapshot.documents {
                 await fetchPostData(documentID: document.documentID, inputType: InputPostType.highlight)
             }


### PR DESCRIPTION
#150 

## 기능
현재 프로필에서 게시글들 최신순으로 불러오게 수정
## 작업내용 
- [x] 파도 / 보낸파도 - "created_Time" 기준으로 최신순으로 정렬
- [x] 하이라이트 - "sendHeartTime" 기준으로 최신순으로 정렬
## 이슈사항
없음