### PR TITLE
[Add] Feature/firebase - 파도, 파도타기 삭제기능 구현

### DIFF
--- a/PADO/PADO/iOS/Helpers/Services/DeletePost.swift
+++ b/PADO/PADO/iOS/Helpers/Services/DeletePost.swift
@@ -16,8 +16,14 @@ class DeletePost {
     let db = Firestore.firestore()
     let storageRef = Storage.storage().reference()
     
-    func deletePost(postID: String) {
+    func deletePost(postID: String, postOwnerID: String, sufferID: String) async throws {
+        try await db.collection("post").document(postID).delete()
+        try await db.collection("users").document(postOwnerID).collection("mypost").document(postID).delete()
+        //postOwnerID 는 오너 아이디가 들어감
+        try await db.collection("users").document(sufferID).collection("sendpost").document(postID).delete()
         
+        let imageRef = storageRef.child("post")
+        try await imageRef.child(postID).delete()
     }
     
     func deletePadoridePost(postID: String, storageFileName: String, subID: String) async throws {

--- a/PADO/PADO/iOS/MainView/Feed/Cell/FeedCell.swift
+++ b/PADO/PADO/iOS/MainView/Feed/Cell/FeedCell.swift
@@ -9,6 +9,7 @@ import Firebase
 import FirebaseFirestoreSwift
 import Kingfisher
 import Lottie
+import PopupView
 import SwiftUI
 
 struct FeedCell: View {
@@ -449,36 +450,46 @@ struct FeedCell: View {
                                     if let padoRideIndex = feedVM.currentPadoRideIndex {
                                         if post.ownerUid == userNameID {
                                             // 내가 받은 게시물의 멍게 삭제 로직
-                                            // post.ownerUid == userNameID && 포스트 - 파도라이드 - 오너아이디 == userNameID
-                                            // 파도라이드 서브 컬렉션에 post ownner uid 추가 필요
-                                            print("2")
+                                            let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
+                                            let subID = feedVM.padoRidePosts[padoRideIndex].id
+                                            
+                                            Task {
+                                                try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
+                                                                                               storageFileName: fileName,
+                                                                                               subID: subID ?? "")
+                                            }
                                             
                                         } else if feedVM.padoRidePosts[padoRideIndex].id == userNameID {
                                             // 내가 보낸 멍게의 삭제 로직
-                                            // 포스트 - 파도라이드 - 다큐먼트 네임 == userNameID
-                                            // 완료
-                                            print("3")
                                             let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
                                             
                                             Task {
                                                 try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
-                                                                                               storageFileName: fileName, 
+                                                                                               storageFileName: fileName,
                                                                                                subID: userNameID)
                                             }
                                         }
-                                    }
-                                    if post.ownerUid == userNameID {
-                                        // 내가 받은 게시물 삭제 로직
-                                        print("1")
-                                    } else if post.surferUid == userNameID {
-                                        print("================")
-                                        // 내가 보낸 게시물 삭제 로직
-                                        print("4")
                                     } else {
-                                        if !userNameID.isEmpty {
-                                            isShowingReportView.toggle()
+                                        if post.ownerUid == userNameID {
+                                            // 내가 받은 게시물 삭제 로직
+                                            Task {
+                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                                                       postOwnerID: post.ownerUid,
+                                                                                       sufferID: post.surferUid)
+                                            }
+                                        } else if post.surferUid == userNameID {
+                                            // 내가 보낸 게시물 삭제 로직
+                                            Task {
+                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                                                       postOwnerID: post.ownerUid,
+                                                                                       sufferID: post.surferUid)
+                                            }
                                         } else {
-                                            isShowingLoginPage = true
+                                            if !userNameID.isEmpty {
+                                                isShowingReportView.toggle()
+                                            } else {
+                                                isShowingLoginPage = true
+                                            }
                                         }
                                     }
                                 } label: {

--- a/PADO/PADO/iOS/MainView/Feed/Cell/FeedCell.swift
+++ b/PADO/PADO/iOS/MainView/Feed/Cell/FeedCell.swift
@@ -25,6 +25,11 @@ struct FeedCell: View {
     @State private var isShowingCommentView: Bool = false
     @State private var isShowingLoginPage: Bool = false
     
+    @State private var deleteMyPadoride: Bool = false
+    @State private var deleteSendPadoride: Bool = false
+    @State private var deleteMyPost: Bool = false
+    @State private var deleteSendPost: Bool = false
+    
     @ObservedObject var feedVM: FeedViewModel
     @ObservedObject var surfingVM: SurfingViewModel
     @ObservedObject var profileVM: ProfileViewModel
@@ -110,7 +115,7 @@ struct FeedCell: View {
                         }
                     }
             } else if let currentIndex = feedVM.currentPadoRideIndex,
-                        feedVM.padoRidePosts.indices.contains(currentIndex) {
+                      feedVM.padoRidePosts.indices.contains(currentIndex) {
                 // PadoRide 이미지 표시
                 let padoRide = feedVM.padoRidePosts[currentIndex]
                 
@@ -450,40 +455,24 @@ struct FeedCell: View {
                                     if let padoRideIndex = feedVM.currentPadoRideIndex {
                                         if post.ownerUid == userNameID {
                                             // 내가 받은 게시물의 멍게 삭제 로직
-                                            let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
-                                            let subID = feedVM.padoRidePosts[padoRideIndex].id
-                                            
-                                            Task {
-                                                try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
-                                                                                               storageFileName: fileName,
-                                                                                               subID: subID ?? "")
-                                            }
-                                            
+                                            deleteMyPadoride = true
                                         } else if feedVM.padoRidePosts[padoRideIndex].id == userNameID {
                                             // 내가 보낸 멍게의 삭제 로직
-                                            let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
-                                            
-                                            Task {
-                                                try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
-                                                                                               storageFileName: fileName,
-                                                                                               subID: userNameID)
+                                            deleteSendPadoride = true
+                                        } else {
+                                            if !userNameID.isEmpty {
+                                                isShowingReportView.toggle()
+                                            } else {
+                                                isShowingLoginPage = true
                                             }
                                         }
                                     } else {
                                         if post.ownerUid == userNameID {
                                             // 내가 받은 게시물 삭제 로직
-                                            Task {
-                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
-                                                                                       postOwnerID: post.ownerUid,
-                                                                                       sufferID: post.surferUid)
-                                            }
+                                            deleteMyPost = true
                                         } else if post.surferUid == userNameID {
                                             // 내가 보낸 게시물 삭제 로직
-                                            Task {
-                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
-                                                                                       postOwnerID: post.ownerUid,
-                                                                                       sufferID: post.surferUid)
-                                            }
+                                            deleteSendPost = true
                                         } else {
                                             if !userNameID.isEmpty {
                                                 isShowingReportView.toggle()
@@ -532,6 +521,165 @@ struct FeedCell: View {
                 }
             }
         }
+        .popup(isPresented: $deleteMyPadoride) {
+            // 내가 받은 게시글의 파도타기를 삭제
+            VStack {
+                Text("해당 파도타기를 삭제하시겠습니까?")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                Button {
+                    let fileName = feedVM.padoRidePosts[feedVM.currentPadoRideIndex ?? 0].storageFileName
+                    let subID = feedVM.padoRidePosts[feedVM.currentPadoRideIndex ?? 0].id
+                    
+                    Task {
+                        try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
+                                                                       storageFileName: fileName,
+                                                                       subID: subID ?? "")
+                        deleteMyPadoride = false
+                    }
+                } label: {
+                    Text("삭제")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                }
+                
+                Button {
+                    deleteMyPadoride = false
+                } label: {
+                    Text("취소")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+            }
+        } customize: {
+            $0
+                .type(.floater())
+                .position(.bottom)
+                .animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
+        }
+        .popup(isPresented: $deleteSendPadoride) {
+            // 상대방 게시글의 내가 보낸 파도타기를 삭제
+            VStack {
+                Text("해당 파도타기를 삭제하시겠습니까?")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                Button {
+                    let fileName = feedVM.padoRidePosts[feedVM.currentPadoRideIndex ?? 0].storageFileName
+                    
+                    Task {
+                        try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
+                                                                       storageFileName: fileName,
+                                                                       subID: userNameID)
+                        deleteSendPadoride = false
+                    }
+                } label: {
+                    Text("삭제")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+                
+                Button {
+                    deleteSendPadoride = false
+                } label: {
+                    Text("취소")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+            }
+        } customize: {
+            $0
+                .type(.floater())
+                .position(.bottom)
+                .animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
+        }
+        .popup(isPresented: $deleteMyPost) {
+            // 내가 받은 파도를 삭제
+            VStack {
+                Text("해당 파도를 삭제하시겠습니까?")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                Button {
+                    Task {
+                        try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                               postOwnerID: post.ownerUid,
+                                                               sufferID: post.surferUid)
+                        deleteMyPost = false
+                    }
+                } label: {
+                    Text("삭제")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+                
+                Button {
+                    deleteMyPost = false
+                } label: {
+                    Text("취소")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+            }
+        } customize: {
+            $0
+                .type(.floater())
+                .position(.bottom)
+                .animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
+        }
+
+        .popup(isPresented: $deleteSendPost) {
+            // 내가 보낸 파도를 삭제
+            VStack {
+                Text("해당 파도를 삭제하시겠습니까?")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                Button {
+                    Task {
+                        try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                               postOwnerID: post.ownerUid,
+                                                               sufferID: post.surferUid)
+                        deleteSendPost = false
+                    }
+                } label: {
+                    Text("삭제")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+                
+                Button {
+                    deleteSendPost = false
+                } label: {
+                    Text("취소")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+            }
+        } customize: {
+            $0
+                .type(.floater())
+                .position(.bottom)
+                .animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
+        }
+
     }
     
     func fetchPostData(post: Post) async {

--- a/PADO/PADO/iOS/MainView/Feed/Cell/FeedCell.swift
+++ b/PADO/PADO/iOS/MainView/Feed/Cell/FeedCell.swift
@@ -640,7 +640,6 @@ struct FeedCell: View {
                 .closeOnTapOutside(true)
                 .backgroundColor(.black.opacity(0.5))
         }
-
         .popup(isPresented: $deleteSendPost) {
             // 내가 보낸 파도를 삭제
             VStack {

--- a/PADO/PADO/iOS/Profile/ProfileGrid/Cell/SelectPostCell.swift
+++ b/PADO/PADO/iOS/Profile/ProfileGrid/Cell/SelectPostCell.swift
@@ -9,6 +9,7 @@ import Firebase
 import FirebaseFirestoreSwift
 import Kingfisher
 import Lottie
+import PopupView
 import SwiftUI
 
 struct SelectPostCell: View {
@@ -381,40 +382,40 @@ struct SelectPostCell: View {
                                     if let padoRideIndex = feedVM.currentPadoRideIndex {
                                         if post.ownerUid == userNameID {
                                             // 내가 받은 게시물의 멍게 삭제 로직
-                                            // 완료
-                                            print("2")
-                                            
                                             let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
                                             let subID = feedVM.padoRidePosts[padoRideIndex].id
                                             
                                             Task {
                                                 try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
-                                                                                               storageFileName: fileName, 
+                                                                                               storageFileName: fileName,
                                                                                                subID: subID ?? "")
                                             }
                                             
-                                            
                                         } else if feedVM.padoRidePosts[padoRideIndex].id == userNameID {
                                             // 내가 보낸 멍게의 삭제 로직
-                                            // 포스트 - 파도라이드 - 다큐먼트 네임 == userNameID
-                                            // 완료
-                                            print("3")
                                             let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
                                             
                                             Task {
                                                 try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
-                                                                                               storageFileName: fileName, 
+                                                                                               storageFileName: fileName,
                                                                                                subID: userNameID)
                                             }
                                         }
                                     } else {
                                         if post.ownerUid == userNameID {
                                             // 내가 받은 게시물 삭제 로직
-                                            print("1")
+                                            Task {
+                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                                                       postOwnerID: post.ownerUid,
+                                                                                       sufferID: post.surferUid)
+                                            }
                                         } else if post.surferUid == userNameID {
-                                            print("================")
                                             // 내가 보낸 게시물 삭제 로직
-                                            print("4")
+                                            Task {
+                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                                                       postOwnerID: post.ownerUid,
+                                                                                       sufferID: post.surferUid)
+                                            }
                                         } else {
                                             if !userNameID.isEmpty {
                                                 isShowingReportView.toggle()

--- a/PADO/PADO/iOS/Profile/ProfileGrid/Cell/SelectPostCell.swift
+++ b/PADO/PADO/iOS/Profile/ProfileGrid/Cell/SelectPostCell.swift
@@ -31,6 +31,11 @@ struct SelectPostCell: View {
     @State private var isShowingCommentView: Bool = false
     @State private var isShowingLoginPage: Bool = false
     
+    @State private var deleteMyPadoride: Bool = false
+    @State private var deleteSendPadoride: Bool = false
+    @State private var deleteMyPost: Bool = false
+    @State private var deleteSendPost: Bool = false
+    
     @Binding var post: Post
     let cellType: PostViewType
     
@@ -382,40 +387,24 @@ struct SelectPostCell: View {
                                     if let padoRideIndex = feedVM.currentPadoRideIndex {
                                         if post.ownerUid == userNameID {
                                             // 내가 받은 게시물의 멍게 삭제 로직
-                                            let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
-                                            let subID = feedVM.padoRidePosts[padoRideIndex].id
-                                            
-                                            Task {
-                                                try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
-                                                                                               storageFileName: fileName,
-                                                                                               subID: subID ?? "")
-                                            }
-                                            
+                                            deleteMyPadoride = true
                                         } else if feedVM.padoRidePosts[padoRideIndex].id == userNameID {
                                             // 내가 보낸 멍게의 삭제 로직
-                                            let fileName = feedVM.padoRidePosts[padoRideIndex].storageFileName
-                                            
-                                            Task {
-                                                try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
-                                                                                               storageFileName: fileName,
-                                                                                               subID: userNameID)
+                                            deleteSendPadoride = true
+                                        } else {
+                                            if !userNameID.isEmpty {
+                                                isShowingReportView.toggle()
+                                            } else {
+                                                isShowingLoginPage = true
                                             }
                                         }
                                     } else {
                                         if post.ownerUid == userNameID {
                                             // 내가 받은 게시물 삭제 로직
-                                            Task {
-                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
-                                                                                       postOwnerID: post.ownerUid,
-                                                                                       sufferID: post.surferUid)
-                                            }
+                                            deleteMyPost = true
                                         } else if post.surferUid == userNameID {
                                             // 내가 보낸 게시물 삭제 로직
-                                            Task {
-                                                try await DeletePost.shared.deletePost(postID: post.id ?? "",
-                                                                                       postOwnerID: post.ownerUid,
-                                                                                       sufferID: post.surferUid)
-                                            }
+                                            deleteSendPost = true
                                         } else {
                                             if !userNameID.isEmpty {
                                                 isShowingReportView.toggle()
@@ -462,6 +451,122 @@ struct SelectPostCell: View {
                 self.postOwnerButtonOnOff =  UpdateFollowData.shared.checkFollowingStatus(id: post.ownerUid)
                 self.postSurferButtonOnOff =  UpdateFollowData.shared.checkFollowingStatus(id: post.surferUid)
             }
+        }
+        .popup(isPresented: $deleteSendPadoride) {
+            // 상대방 게시글의 내가 보낸 파도타기를 삭제
+            VStack {
+                Text("해당 파도타기를 삭제하시겠습니까?")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                Button {
+                    let fileName = feedVM.padoRidePosts[feedVM.currentPadoRideIndex ?? 0].storageFileName
+                    
+                    Task {
+                        try await DeletePost.shared.deletePadoridePost(postID: post.id ?? "",
+                                                                       storageFileName: fileName,
+                                                                       subID: userNameID)
+                        deleteSendPadoride = false
+                    }
+                } label: {
+                    Text("삭제")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+                
+                Button {
+                    deleteSendPadoride = false
+                } label: {
+                    Text("취소")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+            }
+        } customize: {
+            $0
+                .type(.floater())
+                .position(.bottom)
+                .animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
+        }
+        .popup(isPresented: $deleteMyPost) {
+            // 내가 받은 파도를 삭제
+            VStack {
+                Text("해당 파도를 삭제하시겠습니까?")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                Button {
+                    Task {
+                        try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                               postOwnerID: post.ownerUid,
+                                                               sufferID: post.surferUid)
+                        deleteMyPost = false
+                    }
+                } label: {
+                    Text("삭제")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+                
+                Button {
+                    deleteMyPost = false
+                } label: {
+                    Text("취소")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+            }
+        } customize: {
+            $0
+                .type(.floater())
+                .position(.bottom)
+                .animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
+        }
+        .popup(isPresented: $deleteSendPost) {
+            // 내가 보낸 파도를 삭제
+            VStack {
+                Text("해당 파도를 삭제하시겠습니까?")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                Button {
+                    Task {
+                        try await DeletePost.shared.deletePost(postID: post.id ?? "",
+                                                               postOwnerID: post.ownerUid,
+                                                               sufferID: post.surferUid)
+                        deleteSendPost = false
+                    }
+                } label: {
+                    Text("삭제")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .foregroundStyle(.red)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+                
+                Button {
+                    deleteSendPost = false
+                } label: {
+                    Text("취소")
+                        .frame(width: UIScreen.main.bounds.width * 0.9, height: 40)
+                        .background(.grayButton)
+                        .cornerRadius(10)
+                }
+            }
+        } customize: {
+            $0
+                .type(.floater())
+                .position(.bottom)
+                .animation(.spring())
+                .closeOnTapOutside(true)
+                .backgroundColor(.black.opacity(0.5))
         }
     }
     


### PR DESCRIPTION
## #️⃣연관된 이슈

#217 - 파도, 멍게 삭제기능 구현

## 📝작업 내용

[🌊 Feat: 내가 받은 게시물의 멍게 삭제 로직](https://github.com/4T2F/PADO/commit/02baac88f6ccd05a141bcab35750028c204d8b24)

[🌊 Feat: 내가 보낸 멍게의 삭제 로직](https://github.com/4T2F/PADO/commit/7edad325f71889fc70684b710359541fdf6c9177)

[🌊 Feat: 내가 받은, 내가 쓴 게시물 삭제 로직 구현](https://github.com/4T2F/PADO/commit/c8da046a2b020eb6bdd15a8bd9a288ee3e21ed39)

[🌊 Feat: 삭제시 모달을 통한 삭제여부 확인 구현](https://github.com/4T2F/PADO/commit/e922de8843697107de6cb412e33c597b88c7f8fb)

[🌊 Feat: 삭제 기능 SelectPostCell 적용](https://github.com/4T2F/PADO/commit/11cb86a6646cf78faaa218dad50aedbba1e9e305)

[Merge branch 'develop' into feature/Firebase](https://github.com/4T2F/PADO/commit/fec7e870a507f43cfaf3e9aada6a5c3b6e480540)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 현재 popupView 디자인 수정 필요 로직만 구현 상태
