### PR TITLE
🐞 Fix: 상대방 방명록이 열리지 않던 오류 수정

### DIFF
--- a/PADO/PADO/iOS/Feed/Cell/FeedHeaderCell.swift
+++ b/PADO/PADO/iOS/Feed/Cell/FeedHeaderCell.swift
@@ -18,6 +18,8 @@ struct FeedHeaderCell: View {
     
     @Namespace var animation
     
+    var openPostit: () -> Void
+    
     private var filterBarWidth: CGFloat {
         let count = CGFloat(FeedFilter.allCases.count)
         return UIScreen.main.bounds.width / count - 140
@@ -59,7 +61,8 @@ struct FeedHeaderCell: View {
             Spacer()
             
             if !userNameID.isEmpty {
-                NavigationLink(destination: NotificationView(notiVM: notiVM)) {
+                NavigationLink(destination: NotificationView(notiVM: notiVM,
+                                                             openPostit: openPostit)) {
                     Image(notiVM.hasNewNotifications ? "Bell_pin_light" : "Bell_light") // 조건부 아이콘 변경
                 }
             } else {

--- a/PADO/PADO/iOS/Feed/View/FeedView.swift
+++ b/PADO/PADO/iOS/Feed/View/FeedView.swift
@@ -8,8 +8,9 @@
 import Lottie
 import SwiftUI
 
-protocol FeedRefreshDelegate {
+protocol FeedDelegate {
     func feedRefresh() async
+    func openPostit()
 }
 
 struct FeedView: View {
@@ -20,7 +21,7 @@ struct FeedView: View {
     @ObservedObject var feedVM: FeedViewModel
     @ObservedObject var notiVM: NotificationViewModel
     
-    var delegate: FeedRefreshDelegate
+    var delegate: FeedDelegate
 
     var body: some View {
         NavigationStack {
@@ -83,7 +84,8 @@ struct FeedView: View {
                 }
                 VStack {
                     if scrollDelegate.scrollOffset < 5 {
-                        FeedHeaderCell(notiVM: notiVM)
+                        FeedHeaderCell(notiVM: notiVM,
+                                       openPostit: { delegate.openPostit() })
                             .transition(.opacity.combined(with: .scale))
                     } else if !scrollDelegate.isEligible {
                         FeedRefreshHeaderCell()

--- a/PADO/PADO/iOS/Main/View/ContentView.swift
+++ b/PADO/PADO/iOS/Main/View/ContentView.swift
@@ -37,7 +37,8 @@ struct ContentView: View {
     
     var body: some View {
         TabView(selection: $viewModel.showTab) {
-            FeedView(feedVM: feedVM, notiVM: notiVM,
+            FeedView(feedVM: feedVM,
+                     notiVM: notiVM,
                      delegate: self)
             .tag(0)
             
@@ -199,13 +200,13 @@ extension ContentView {
             try? await Task.sleep(nanoseconds: 1 * 500_000_000)
             viewModel.showTab = 4
             try? await Task.sleep(nanoseconds: 1 * 250_000_000)
-            viewModel.isShowingMessageView = true
+            profileVM.isShowingMessageView = true
         }
     }
 }
 
 // MARK: FeedView에서 사용 될 Refresh 함수
-extension ContentView: FeedRefreshDelegate {
+extension ContentView: FeedDelegate {
     func feedRefresh() async {
         try? await Task.sleep(nanoseconds: 1_500_000_000)
         if viewModel.selectedFilter == FeedFilter.following {
@@ -236,5 +237,9 @@ extension ContentView: FeedRefreshDelegate {
                 await notiVM.fetchNotifications()
             }
         }
+    }
+    
+    func openPostit() {
+        profileVM.isShowingMessageView = true
     }
 }

--- a/PADO/PADO/iOS/Main/ViewModel/MainViewModel.swift
+++ b/PADO/PADO/iOS/Main/ViewModel/MainViewModel.swift
@@ -14,7 +14,6 @@ import SwiftUI
 class MainViewModel: ObservableObject {
     
     @Published var showLaunchScreen = true
-    @Published var isShowingMessageView = false
 
     // 탭바 이동관련 변수
     @Published var showTab: Int = 0

--- a/PADO/PADO/iOS/Notification/Cell/PostitNotificationCell.swift
+++ b/PADO/PADO/iOS/Notification/Cell/PostitNotificationCell.swift
@@ -16,6 +16,7 @@ struct PostitNotificationCell: View {
     @Environment(\.dismiss) var dismiss
 
     var notification: Noti
+    var openPostit: () -> Void
     
     var body: some View {
         if let user = notiVM.notiUser[notification.sendUser] {
@@ -25,7 +26,7 @@ struct PostitNotificationCell: View {
                     try? await Task.sleep(nanoseconds: 1 * 500_000_000)
                     viewModel.showTab = 4
                     try? await Task.sleep(nanoseconds: 1 * 250_000_000)
-                    viewModel.isShowingMessageView = true
+                    openPostit()
                 }
             } label: {
                 HStack(spacing: 0) {

--- a/PADO/PADO/iOS/Notification/View/NotificationCell.swift
+++ b/PADO/PADO/iOS/Notification/View/NotificationCell.swift
@@ -11,6 +11,7 @@ struct NotificationCell: View {
     @ObservedObject var notiVM: NotificationViewModel
     
     var notification: Noti
+    var openPostit: () -> Void
     
     var body: some View {
         switch notification.type { // 노티의 타입마다 분기처리
@@ -37,7 +38,8 @@ struct NotificationCell: View {
                                    notification: notification)
         case "postit":
             PostitNotificationCell(notiVM: notiVM,
-                                   notification: notification)
+                                   notification: notification,
+                                   openPostit: openPostit)
         case "padoRide":
             PadoRideNotificationCell(notiVM: notiVM, 
                                      notification: notification)

--- a/PADO/PADO/iOS/Notification/View/NotificationView.swift
+++ b/PADO/PADO/iOS/Notification/View/NotificationView.swift
@@ -14,6 +14,8 @@ struct NotificationView: View {
     
     @State private var fetchedNotiData: Bool = false
     
+    var openPostit: () -> Void
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -37,7 +39,8 @@ struct NotificationView: View {
                         if fetchedNotiData {
                             ForEach(notiVM.notifications.indices, id: \.self) { index in
                                 NotificationCell(notiVM: notiVM,
-                                                 notification: notiVM.notifications[index])
+                                                 notification: notiVM.notifications[index],
+                                                 openPostit: openPostit)
                                 .id(index)
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 8)

--- a/PADO/PADO/iOS/Profile/View/OtherUserProfileView.swift
+++ b/PADO/PADO/iOS/Profile/View/OtherUserProfileView.swift
@@ -10,7 +10,6 @@ import Lottie
 import SwiftUI
 
 struct OtherUserProfileView: View {
-    @EnvironmentObject var viewModel: MainViewModel
     @Environment(\.dismiss) var dismiss
     
     @StateObject var profileVM = ProfileViewModel()

--- a/PADO/PADO/iOS/Profile/View/ProfileHeaderView.swift
+++ b/PADO/PADO/iOS/Profile/View/ProfileHeaderView.swift
@@ -61,7 +61,7 @@ struct ProfileHeaderView: View {
                                 }
                                 .overlay {
                                     Button {
-                                        viewModel.isShowingMessageView = true
+                                        profileVM.isShowingMessageView = true
                                     } label: {
                                         Circle()
                                             .frame(width: 30)
@@ -83,9 +83,9 @@ struct ProfileHeaderView: View {
                                             }
                                     }
                                     .offset(x: 46, y: -40)
-                                    .sheet(isPresented: $viewModel.isShowingMessageView) {
+                                    .sheet(isPresented: $profileVM.isShowingMessageView) {
                                         PostitView(postitVM: postitVM,
-                                                   isShowingMessageView: $viewModel.isShowingMessageView)
+                                                   isShowingMessageView: $profileVM.isShowingMessageView)
                                         .presentationDragIndicator(.visible)
                                     }
                                     .presentationDetents([.large])

--- a/PADO/PADO/iOS/Profile/ViewModel/ProfileViewModel.swift
+++ b/PADO/PADO/iOS/Profile/ViewModel/ProfileViewModel.swift
@@ -51,6 +51,8 @@ class ProfileViewModel: ObservableObject {
     // 사용자 차단 로직
     @Published var isUserBlocked: Bool = false
     
+    // 방명록 모달
+    @Published var isShowingMessageView = false
     // 신고 모달
     @Published var isShowingReportView: Bool = false
     // 로그인이 안되어있을 때


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
MainViewModel에 있는 isShowingMessageView을 이용하여 방명록을 열어서 상대방 프로필에서 방명록을 열어도 내 방명록이 열리던 문제 발생 

-> 

ProfileViewModel로 isShowingMessageView 변수를 이동 
+ 알림쪽에선 delegate을 통해 ProfileViewModel의 변수에 접근하도록 수정하여 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
